### PR TITLE
chore: remove webpack analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
+package-lock.json

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -112,9 +112,4 @@ if (config.build.productionGzip) {
   )
 }
 
-if (config.build.bundleAnalyzerReport) {
-  var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-  webpackConfig.plugins.push(new BundleAnalyzerPlugin())
-}
-
 module.exports = webpackConfig

--- a/config/index.js
+++ b/config/index.js
@@ -14,12 +14,7 @@ module.exports = {
     // Before setting to `true`, make sure to:
     // npm install --save-dev compression-webpack-plugin
     productionGzip: false,
-    productionGzipExtensions: ['js', 'css'],
-    // Run the build command with an extra argument to
-    // View the bundle analyzer report after build finishes:
-    // `npm run build --report`
-    // Set to `true` or `false` to always turn it on or off
-    bundleAnalyzerReport: process.env.npm_config_report
+    productionGzipExtensions: ['js', 'css']
   },
   dev: {
     env: require('./dev.env'),

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.3.3",
     "webpack": "^2.6.1",
-    "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.18.0",
     "webpack-merge": "^4.1.0"


### PR DESCRIPTION
针对 Github 报的安全警告的修改。

1. package-lock.json 中有很多包有安全漏洞，很难一一升级，鉴于大部分开源组件都不提交该文件，因此将该文件忽略掉。

2. 项目中的 webpack-bundle-analyzer 用于分析 demo 的打包大小，没什么必要，也移除掉了。